### PR TITLE
Add filings feature with ingestion and storage support

### DIFF
--- a/TradingPlatform.Api/Features/Filings/FilingsEndpoint.cs
+++ b/TradingPlatform.Api/Features/Filings/FilingsEndpoint.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Carter;
+using Microsoft.AspNetCore.Routing;
+using TradingPlatform.Application.Ingestion;
+
+namespace TradingPlatform.Api.Features.Filings;
+
+/// <summary>Filings endpoints (backfill + daily) לפי מבנה Features.</summary>
+public sealed class FilingsEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        // שומר על ה-URLs שהצענו קודם כדי לא לשבור לקוחות
+        app.MapPost("/ingestion/filings/backfill", async (int days, FilingsBackfillJob job, CancellationToken ct) =>
+        {
+            var inserted = await job.RunAsync(days, ct);
+            return Results.Ok(new { inserted, days });
+        });
+
+        app.MapPost("/ingestion/filings/daily/run", async (FilingsDailyJob job, CancellationToken ct) =>
+        {
+            var inserted = await job.RunAsync(ct);
+            return Results.Ok(new { inserted });
+        });
+    }
+}

--- a/TradingPlatform.Api/Program.cs
+++ b/TradingPlatform.Api/Program.cs
@@ -1,26 +1,40 @@
 ﻿// src/TradingPlatform.Api/Program.cs
+using System;
 using Carter;
+
+// Prices (P2)
 using TradingPlatform.Application.Prices;
+using TradingPlatform.Infrastructure.Prices;
+
+// News (P3)
 using TradingPlatform.Application.News;
 using TradingPlatform.Domain.Ingestion;
-using TradingPlatform.Infrastructure.Common;
-using TradingPlatform.Infrastructure.Prices;
-using TradingPlatform.Infrastructure.Symbols;
 using TradingPlatform.Infrastructure.News;
+
+// Symbols (P1)
+using TradingPlatform.Infrastructure.Symbols;
+
+// Common DB
+using TradingPlatform.Infrastructure.Common;
+
+// Filings (P4)
+using TradingPlatform.Application.Ingestion;
+using TradingPlatform.Domain.Filings;
+using TradingPlatform.Infrastructure.Filings;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// === Services (DI) ===
+// ========== Services (DI) ==========
 builder.Services.AddCarter();
 
 // DB helper
 builder.Services.AddSingleton<IDb, Db>();
 builder.Services.AddSingleton(sp => (Db)sp.GetRequiredService<IDb>());
 
-// Symbols (Prompt 1)
+// ---------- Symbols (Prompt 1) ----------
 builder.Services.AddSingleton<ISymbolRegistry, SqlSymbolRegistry>();
 
-// Prices (Prompt 2)
+// ---------- Prices (Prompt 2) ----------
 var dbMode = builder.Configuration["Db:Mode"] ?? "Real";
 if (string.Equals(dbMode, "Noop", StringComparison.OrdinalIgnoreCase))
     builder.Services.AddSingleton<IPriceRepository, NoopPriceRepository>();
@@ -32,7 +46,7 @@ builder.Services.AddSingleton<PricesDailyJob>();
 if (builder.Configuration.GetValue("Prices:EnableDailyJob", true))
     builder.Services.AddHostedService(sp => sp.GetRequiredService<PricesDailyJob>());
 
-// News (Prompt 3)
+// ---------- News (Prompt 3) ----------
 builder.Services.Configure<IngestionOptions>(builder.Configuration.GetSection(IngestionOptions.SectionName));
 builder.Services.AddHttpClient(nameof(RssNewsSource)).SetHandlerLifetime(TimeSpan.FromMinutes(5));
 builder.Services.AddSingleton<INewsRepository>(sp =>
@@ -40,12 +54,19 @@ builder.Services.AddSingleton<INewsRepository>(sp =>
 builder.Services.AddSingleton<INewsSource, RssNewsSource>();
 builder.Services.AddSingleton<NewsIngestionUseCase>();
 builder.Services.AddSingleton<NewsBackfillJob>();
-
-var enableNewsDaily = builder.Configuration.GetValue("News:EnableDailyJob", false); // default=false
-if (enableNewsDaily)
+if (builder.Configuration.GetValue("News:EnableDailyJob", false))
     builder.Services.AddHostedService<NewsDailyJob>();
 
-// === App ===
+// ---------- Filings (Prompt 4) ----------
+builder.Services.AddSingleton<IFilingsRepository>(sp =>
+    new SqlFilingsRepository(builder.Configuration.GetConnectionString("TradingPlatformNet8")!));
+builder.Services.AddSingleton<IFilingsSource, DummyFilingsSource>();
+builder.Services.AddScoped<FilingsBackfillJob>();
+builder.Services.AddScoped<FilingsDailyJob>();
+if (builder.Configuration.GetValue("Filings:EnableDailyJob", true))
+    builder.Services.AddHostedService<FilingsDailyWorker>();
+
+// ========== App ==========
 var app = builder.Build();
 
 app.MapGet("/health", () => Results.Ok(new { status = "ok" }));

--- a/TradingPlatform.Api/appsettings.json
+++ b/TradingPlatform.Api/appsettings.json
@@ -3,6 +3,10 @@
   "ConnectionStrings": {
     "TradingPlatformNet8": "Server=.;Database=TradingPlatformNet8;Trusted_Connection=True;TrustServerCertificate=True"
   },
+  "Filings": {
+    "EnableDailyJob": false, // להרצה ידנית ע"י Postman
+    "DailyIntervalMinutes": 1440
+  },
   "Ingestion": {
     "Feeds": [ "https://www.nasdaq.com/feed/rssoutbound?category=Stocks", "https://www.ynet.co.il/3rdparty/rss/economy.xml" ]
   },

--- a/TradingPlatform.Application/Ingestion/FilingsBackfillJob.cs
+++ b/TradingPlatform.Application/Ingestion/FilingsBackfillJob.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TradingPlatform.Domain.Filings;
+
+namespace TradingPlatform.Application.Ingestion;
+
+/// <summary>Backfills filings for the last N days via source → repo (SP-Only).</summary>
+public sealed class FilingsBackfillJob
+{
+    private readonly IFilingsSource _source;
+    private readonly IFilingsRepository _repo;
+    private readonly ILogger<FilingsBackfillJob> _logger;
+
+    public FilingsBackfillJob(IFilingsSource source, IFilingsRepository repo, ILogger<FilingsBackfillJob> logger)
+    {
+        _source = source;
+        _repo = repo;
+        _logger = logger;
+    }
+
+    public async Task<int> RunAsync(int daysBack, CancellationToken ct)
+    {
+        var items = await _source.FetchAsync(daysBack, ct);
+        var inserted = await _repo.UpsertAsync(items, ct);
+        _logger.LogInformation("FilingsBackfill inserted: {Inserted}", inserted);
+        return inserted;
+    }
+}

--- a/TradingPlatform.Application/Ingestion/FilingsDailyJob.cs
+++ b/TradingPlatform.Application/Ingestion/FilingsDailyJob.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TradingPlatform.Domain.Filings;
+
+namespace TradingPlatform.Application.Ingestion;
+
+/// <summary>Daily filings ingestion since last 24h (idempotent by DocHash).</summary>
+public sealed class FilingsDailyJob
+{
+    private readonly IFilingsSource _source;
+    private readonly IFilingsRepository _repo;
+    private readonly ILogger<FilingsDailyJob> _logger;
+
+    public FilingsDailyJob(IFilingsSource source, IFilingsRepository repo, ILogger<FilingsDailyJob> logger)
+    {
+        _source = source;
+        _repo = repo;
+        _logger = logger;
+    }
+
+    public async Task<int> RunAsync(CancellationToken ct)
+    {
+        var since = DateTime.UtcNow.AddDays(-1);
+        var items = await _source.FetchSinceAsync(since, ct);
+        var inserted = await _repo.UpsertAsync(items, ct);
+        _logger.LogInformation("FilingsDaily inserted: {Inserted}", inserted);
+        return inserted;
+    }
+}

--- a/TradingPlatform.Application/Ingestion/FilingsDailyWorker.cs
+++ b/TradingPlatform.Application/Ingestion/FilingsDailyWorker.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace TradingPlatform.Application.Ingestion;
+
+/// <summary>
+/// BackgroundService שמריץ את FilingsDailyJob במחזוריות (ברירת מחדל: פעם ביום).
+/// </summary>
+public sealed class FilingsDailyWorker : BackgroundService
+{
+    private readonly IServiceProvider _sp;
+    private readonly ILogger<FilingsDailyWorker> _logger;
+    private readonly TimeSpan _interval;
+
+    public FilingsDailyWorker(IServiceProvider sp, ILogger<FilingsDailyWorker> logger, IConfiguration cfg)
+    {
+        _sp = sp;
+        _logger = logger;
+        var minutes = cfg.GetValue<int?>("Filings:DailyIntervalMinutes") ?? 1440; // 24h
+        _interval = TimeSpan.FromMinutes(minutes);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // ריצה מידית ואז מחזורית
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = _sp.CreateScope();
+                var job = scope.ServiceProvider.GetRequiredService<FilingsDailyJob>();
+                var inserted = await job.RunAsync(stoppingToken);
+                _logger.LogInformation("FilingsDailyWorker ran. Inserted={Inserted}", inserted);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "FilingsDailyWorker failed.");
+            }
+
+            try { await Task.Delay(_interval, stoppingToken); }
+            catch (OperationCanceledException) { /* shutdown */ }
+        }
+    }
+}

--- a/TradingPlatform.Domain/Filings/Filings.cs
+++ b/TradingPlatform.Domain/Filings/Filings.cs
@@ -1,0 +1,13 @@
+﻿namespace TradingPlatform.Domain.Filings;
+
+/// <summary>Represents a single corporate filing/financial report entry.</summary>
+public sealed record Filing(
+    string Symbol,
+    string FilingType,
+    DateOnly? PeriodStart,
+    DateOnly? PeriodEnd,
+    string Url,
+    string Source,
+    DateTime PublishedAtUtc,
+    byte[] DocHash,
+    string? Lang);

--- a/TradingPlatform.Domain/Filings/IFilingsRepository.cs
+++ b/TradingPlatform.Domain/Filings/IFilingsRepository.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TradingPlatform.Domain.Filings;
+
+/// <summary>Persists filings via Stored Procedures (no inline SQL).</summary>
+public interface IFilingsRepository
+{
+    /// <summary>Bulk upsert filings using TVP to SP (dedupe by DocHash).</summary>
+    Task<int> UpsertAsync(IEnumerable<Filing> items, CancellationToken ct);
+}

--- a/TradingPlatform.Domain/Filings/IFilingsSource.cs
+++ b/TradingPlatform.Domain/Filings/IFilingsSource.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TradingPlatform.Domain.Filings;
+
+/// <summary>Abstract source for fetching filings (e.g., EDGAR/MAYA). Dev may use Dummy.</summary>
+public interface IFilingsSource
+{
+    /// <summary>Fetch filings for the last 'daysBack' days.</summary>
+    Task<IReadOnlyList<Filing>> FetchAsync(int daysBack, CancellationToken ct);
+
+    /// <summary>Fetch filings published since (UTC).</summary>
+    Task<IReadOnlyList<Filing>> FetchSinceAsync(DateTime sinceUtc, CancellationToken ct);
+}

--- a/TradingPlatform.Infrastructure/Filings/DummyFilingsSource.cs
+++ b/TradingPlatform.Infrastructure/Filings/DummyFilingsSource.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TradingPlatform.Domain.Filings;
+
+namespace TradingPlatform.Infrastructure.Filings;
+
+/// <summary>Dev dummy source producing deterministic sample filings.</summary>
+public sealed class DummyFilingsSource : IFilingsSource
+{
+    public Task<IReadOnlyList<Filing>> FetchAsync(int daysBack, CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<Filing>>(Generate(DateTime.UtcNow.AddDays(-daysBack), DateTime.UtcNow));
+
+    public Task<IReadOnlyList<Filing>> FetchSinceAsync(DateTime sinceUtc, CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<Filing>>(Generate(sinceUtc, DateTime.UtcNow));
+
+    private static List<Filing> Generate(DateTime fromUtc, DateTime toUtc)
+    {
+        var list = new List<Filing>();
+        var dates = new[] { toUtc.AddDays(-7), toUtc.AddDays(-30), toUtc.AddDays(-90) };
+        foreach (var (sym, type) in new[] { ("AAPL", "10-Q"), ("MSFT", "10-K"), ("NVDA", "8-K") })
+        {
+            foreach (var d in dates)
+            {
+                if (d < fromUtc || d > toUtc) continue;
+                var url = $"https://example.local/{sym}/{type}/{d:yyyyMMdd}";
+                var src = "DUMMY";
+                var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"{sym}|{type}|{url}|{src}|{d.Ticks}"));
+
+                list.Add(new Filing(
+                    Symbol: sym,
+                    FilingType: type,
+                    PeriodStart: null,
+                    PeriodEnd: null,
+                    Url: url,
+                    Source: src,
+                    PublishedAtUtc: DateTime.SpecifyKind(d, DateTimeKind.Utc),
+                    DocHash: hash,
+                    Lang: "en"));
+            }
+        }
+        return list;
+    }
+}

--- a/TradingPlatform.Infrastructure/Filings/SqlFilingsRepository.cs
+++ b/TradingPlatform.Infrastructure/Filings/SqlFilingsRepository.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using TradingPlatform.Domain.Filings;
+
+namespace TradingPlatform.Infrastructure.Filings;
+
+/// <summary>Dapper repo writing filings via dbo.SP_Filings_UpsertBulk (TVP).</summary>
+public sealed class SqlFilingsRepository : IFilingsRepository
+{
+    private readonly string _cs;
+
+    public SqlFilingsRepository(string connectionString)
+        => _cs = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+
+    public async Task<int> UpsertAsync(IEnumerable<Filing> items, CancellationToken ct)
+    {
+        var dt = new DataTable();
+        dt.Columns.Add("Symbol", typeof(string));
+        dt.Columns.Add("FilingType", typeof(string));
+        dt.Columns.Add("PeriodStart", typeof(DateTime));   // DateOnly? -> DateTime?
+        dt.Columns.Add("PeriodEnd", typeof(DateTime));
+        dt.Columns.Add("Url", typeof(string));
+        dt.Columns.Add("Source", typeof(string));
+        dt.Columns.Add("PublishedAt", typeof(DateTime));
+        dt.Columns.Add("DocHash", typeof(byte[]));
+        dt.Columns.Add("Lang", typeof(string));
+
+        foreach (var f in items)
+        {
+            dt.Rows.Add(
+                f.Symbol,
+                f.FilingType,
+                f.PeriodStart.HasValue ? f.PeriodStart.Value.ToDateTime(TimeOnly.MinValue) : (object)DBNull.Value,
+                f.PeriodEnd.HasValue ? f.PeriodEnd.Value.ToDateTime(TimeOnly.MinValue) : (object)DBNull.Value,
+                f.Url,
+                f.Source,
+                f.PublishedAtUtc,
+                f.DocHash,
+                (object?)f.Lang ?? DBNull.Value
+            );
+        }
+
+        await using var con = new SqlConnection(_cs);
+        var p = new DynamicParameters();
+        p.Add("@Rows", dt.AsTableValuedParameter("dbo.FilingRowType"));
+
+        // Returns single row: { Inserted = int }
+        var result = await con.QuerySingleAsync<int>(
+            new CommandDefinition(
+                commandText: "dbo.SP_Filings_UpsertBulk",
+                parameters: p,
+                commandType: CommandType.StoredProcedure,
+                cancellationToken: ct));
+
+        return result;
+    }
+}

--- a/db/ddl/030_filings_table.sql
+++ b/db/ddl/030_filings_table.sql
@@ -1,0 +1,20 @@
+﻿CREATE TABLE dbo.Filings(
+  Id BIGINT IDENTITY(1,1) PRIMARY KEY,
+  Symbol NVARCHAR(20) NOT NULL,
+  FilingType NVARCHAR(40) NOT NULL,     -- 10-K / 10-Q / 20-F / ImmediateReport / ...
+  PeriodStart DATE NULL,
+  PeriodEnd   DATE NULL,
+  Url NVARCHAR(400) NOT NULL,
+  Source NVARCHAR(100) NOT NULL,        -- EDGAR / MAYA / ...
+  PublishedAt DATETIME2 NOT NULL,
+  DocHash BINARY(32) NOT NULL,          -- SHA256 uniqueness of a document
+  Lang NVARCHAR(10) NULL,
+  CreatedAt DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+);
+GO
+
+CREATE UNIQUE INDEX UX_Filings_DocHash ON dbo.Filings(DocHash);
+GO
+
+CREATE INDEX IX_Filings_Symbol_PublishedAt ON dbo.Filings(Symbol, PublishedAt DESC);
+GO

--- a/db/ddl/031_filings_tvp.sql
+++ b/db/ddl/031_filings_tvp.sql
@@ -1,0 +1,13 @@
+﻿-- TVP for bulk upsert
+CREATE TYPE dbo.FilingRowType AS TABLE(
+  Symbol NVARCHAR(20) NOT NULL,
+  FilingType NVARCHAR(40) NOT NULL,
+  PeriodStart DATE NULL,
+  PeriodEnd   DATE NULL,
+  Url NVARCHAR(400) NOT NULL,
+  Source NVARCHAR(100) NOT NULL,
+  PublishedAt DATETIME2 NOT NULL,
+  DocHash BINARY(32) NOT NULL,
+  Lang NVARCHAR(10) NULL
+);
+GO

--- a/db/sp/SP_Filings_UpsertBulk.sql
+++ b/db/sp/SP_Filings_UpsertBulk.sql
@@ -1,0 +1,19 @@
+﻿CREATE OR ALTER PROCEDURE dbo.SP_Filings_UpsertBulk
+  @Rows dbo.FilingRowType READONLY
+AS
+BEGIN
+  SET NOCOUNT ON;
+
+  DECLARE @ops TABLE([action] NVARCHAR(10));
+
+  MERGE dbo.Filings AS T
+  USING @Rows AS S
+    ON T.DocHash = S.DocHash
+  WHEN NOT MATCHED BY TARGET THEN
+    INSERT (Symbol, FilingType, PeriodStart, PeriodEnd, Url, Source, PublishedAt, DocHash, Lang)
+    VALUES (S.Symbol, S.FilingType, S.PeriodStart, S.PeriodEnd, S.Url, S.Source, S.PublishedAt, S.DocHash, S.Lang)
+  OUTPUT $action INTO @ops;
+
+  SELECT Inserted = COUNT(*) FROM @ops WHERE [action] = 'INSERT';
+END
+GO


### PR DESCRIPTION
This commit introduces a new feature for handling corporate filings in the Trading Platform application. Key changes include:

- Creation of a new `dbo.Filings` table and `SP_Filings_UpsertBulk` stored procedure for bulk upserting filings.
- Definition of a `Filing` record and interfaces `IFilingsRepository` and `IFilingsSource` for data access abstraction.
- Implementation of `SqlFilingsRepository` for database interactions and `DummyFilingsSource` for testing.
- Introduction of `FilingsBackfillJob` and `FilingsDailyJob` for data ingestion, along with a `FilingsDailyWorker` for scheduled execution.
- Addition of `FilingsEndpoint` class to expose API endpoints for triggering ingestion jobs.
- Updates to `appsettings.json` for configuring daily job settings.
- Code cleanup in `Program.cs` for improved organization and removal of unnecessary directives.