### PR TITLE
Add filings source configuration and update settings

### DIFF
--- a/TradingPlatform.Api/appsettings.json
+++ b/TradingPlatform.Api/appsettings.json
@@ -3,13 +3,33 @@
   "ConnectionStrings": {
     "TradingPlatformNet8": "Server=.;Database=TradingPlatformNet8;Trusted_Connection=True;TrustServerCertificate=True"
   },
+
+  "Prices": {
+    "EnableDailyJob": true
+  },
+
+  "News": {
+    "EnableDailyJob": false
+  },
+
   "Filings": {
-    "EnableDailyJob": false, // להרצה ידנית ע"י Postman
-    "DailyIntervalMinutes": 1440
+    "_note": "To use live data, set \"Source\" to \"Edgar\" and configure Filings:Edgar (FeedUrl and UserAgent per SEC requirements).",
+    "Source": "Dummy",
+    "EnableDailyJob": false,
+    "DailyIntervalMinutes": 1440,
+    "Edgar": {
+      "FeedUrl": "https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&owner=include&output=atom",
+      "UserAgent": "trading-platform-net8/0.1 (contact: your-email@your-domain.com)"
+    }
   },
+
   "Ingestion": {
-    "Feeds": [ "https://www.nasdaq.com/feed/rssoutbound?category=Stocks", "https://www.ynet.co.il/3rdparty/rss/economy.xml" ]
+    "Feeds": [
+      "https://www.nasdaq.com/feed/rssoutbound?category=Stocks",
+      "https://www.ynet.co.il/3rdparty/rss/economy.xml"
+    ]
   },
+
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",
@@ -18,7 +38,14 @@
         "System": "Warning"
       }
     },
-    "WriteTo": [ { "Name": "Console" } ],
-    "Enrich": [ "FromLogContext", "WithMachineName", "WithProcessId", "WithThreadId" ]
+    "WriteTo": [
+      { "Name": "Console" }
+    ],
+    "Enrich": [
+      "FromLogContext",
+      "WithMachineName",
+      "WithProcessId",
+      "WithThreadId"
+    ]
   }
 }


### PR DESCRIPTION
Introduced a new configuration option for selecting the source of filings data in `Program.cs`. If `Filings:Source` is set to "Edgar", the application uses `EdgarRssFilingsSource`; otherwise, it defaults to `DummyFilingsSource`. Updated `appsettings.json` to reflect the `EnableDailyJob` settings for both `News` and `Filings`, with the `Filings` section now including a note about live data usage. Reformatted `Serilog` configuration for improved readability.